### PR TITLE
Ignore eslint warnings in firebase front-end code when using alert

### DIFF
--- a/src/client/containers/SignUp/index.js
+++ b/src/client/containers/SignUp/index.js
@@ -21,6 +21,7 @@ export default function SignUpContainer() {
     });
     if (!doesPasswordsMatch) {
       setIsLoading(false);
+      /* eslint-disable no-alert */
       alert("Passwords doesn't match");
       return;
     }

--- a/src/client/firebase/auth.js
+++ b/src/client/firebase/auth.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 function handleAuthErrors({ code, message }) {
   switch (code) {
     case FIREBASE_ERROR_CODES.WRONG_PASSWORD:


### PR DESCRIPTION
# Description

Ignore eslint warnings in firebase front-end code when using alert

Fixes #25 

# How to test?

Eslint warnings regarding use of alerts in firebase code should no longer appear when linting

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
