### PR TITLE
solvedd css class conflict

### DIFF
--- a/src/client/components/GoogleButton/GoogleButton.component.js
+++ b/src/client/components/GoogleButton/GoogleButton.component.js
@@ -4,7 +4,7 @@ import './GoogleButton.css';
 const GoogleButton = () => {
   return (
     <div id="g-button">
-      <span className="icon" />
+      <span className="google-icon" />
       <span className="buttonText">Sign up with Google</span>
     </div>
   );

--- a/src/client/components/GoogleButton/GoogleButton.css
+++ b/src/client/components/GoogleButton/GoogleButton.css
@@ -14,7 +14,7 @@
   cursor: pointer;
 }
 
-span.icon {
+span.google-icon {
   background:
     url('../../assets/images/g-icon.png') transparent 5px 50%
     no-repeat;


### PR DESCRIPTION
# Description

Changed className "icon" for "google-icon".
The ArrowButton component was already using a class named "icon" and the css style sheet of that component was affecting the GoogleButton component.
 

Fixes #6

# How to test?

run the command npm run storybook

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
