### PR TITLE
Revert "Candidate Card variant for result list"

### DIFF
--- a/src/client/components/CandidateCard/CandidateCardItem.component.js
+++ b/src/client/components/CandidateCard/CandidateCardItem.component.js
@@ -12,8 +12,8 @@ export const CardListItem = ({ candidateName }) => {
         </div>
 
         <div>
-          <span className="drag-dots">&#8942;</span>
-          <span className="drag-dots">&#8942;</span>
+          <span>&#8942;</span>
+          <span>&#8942;</span>
         </div>
       </div>
     </li>

--- a/src/client/components/CandidateCard/CandidateCardItem.stories.js
+++ b/src/client/components/CandidateCard/CandidateCardItem.stories.js
@@ -104,20 +104,3 @@ export const CardListExampleDraggable = () => {
     </DragAndSortAdapter>
   );
 };
-
-export const CardListExampleResult = () => {
-  const candidateList = candidateListArr();
-  return (
-    <div className="result-candidate">
-      {candidateList.map((item) => (
-        <CardItemDecorator
-          key={item.id}
-          colorVariant="primary-color"
-          candidateName={item.name}
-          displayDeleteIcon="hidden"
-          onClick={action('clicked')}
-        />
-      ))}
-    </div>
-  );
-};

--- a/src/client/components/CandidateCard/CandidateCardList.style.css
+++ b/src/client/components/CandidateCard/CandidateCardList.style.css
@@ -51,17 +51,3 @@
   visibility: hidden;
   margin-left: -20px;
 }
-
-.result-candidate .drag-dots {
-  visibility: hidden;
-}
-
-.result-candidate .card-title {
-  padding-right: 0;
-  text-align: center;
-  width: 100%;
-}
-
-.result-candidate .card-display {
-  justify-content: center;
-}


### PR DESCRIPTION
Reverts HackYourFuture-CPH/simply-name.it#205

#205  was an attempt to have a Result variant for the Candidate Card component in the easiest way that does not change the component itself so that others would not need to refactor. However, it turned out that such a workaround is not applicable. 

A small workaround will be used for now, just hiding the draggable-dots element and disregarding other styling aspects. Such compromise allows to use the current component and have a satisfactory variant for the Result Page.