### PR TITLE
fix: Add Members page styling to accommodate long names

### DIFF
--- a/src/client/containers/AddMembersPage/AddMembersPage.styles.css
+++ b/src/client/containers/AddMembersPage/AddMembersPage.styles.css
@@ -1,7 +1,7 @@
 .add-members-container {
   width: 414px;
   height: 739px;
-  border: solid 1px grey;
+  border-right: solid 1px grey;
 }
 
 .arrow-button {
@@ -35,7 +35,13 @@
   justify-content: space-between;
   width: 80%;
   margin: auto;
-  padding-top: 5px;
+  padding-top: 15px;
+}
+
+.users-list-item p {
+  inline-size: 150px;
+  overflow: hidden;
+  text-align: center;
 }
 
 .nothing-found-text,


### PR DESCRIPTION
small fix for this:

![image](https://user-images.githubusercontent.com/64137994/131656816-569710ea-04ca-4ede-a50b-0588e5776a76.png)
